### PR TITLE
feat: use DataView instead of ArrayBuffer, fixes #3

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -3,36 +3,45 @@
 const bytes = require('./core')
 
 bytes.from = (_from, _encoding) => {
-  if (_from instanceof ArrayBuffer) return _from
+  if (_from instanceof DataView) return _from
+  if (_from instanceof ArrayBuffer) return new DataView(_from)
   let buffer
   if (typeof _from === 'string') {
     if (!_encoding) {
       _encoding = 'utf-8'
     } else if (_encoding === 'base64') {
       buffer = Uint8Array.from(atob(_from), c => c.charCodeAt(0)).buffer
-      return buffer
+      return new DataView(buffer)
     }
     if (_encoding !== 'utf-8') throw new Error('Browser support for encodings other than utf-8 not implemented')
-    return (new TextEncoder()).encode(_from).buffer
+    return new DataView((new TextEncoder()).encode(_from).buffer)
   } else if (typeof _from === 'object') {
     if (ArrayBuffer.isView(_from)) {
-      if (_from.byteLength === _from.buffer.byteLength) return _from.buffer
-      else return _from.buffer.slice(_from.byteOffset, _from.byteOffset + _from.byteLength)
+      if (_from.byteLength === _from.buffer.byteLength) return new DataView(_from.buffer)
+      else return new DataView(_from.buffer, _from.byteOffset, _from.byteLength)
     }
   }
   throw new Error('Unkown type. Cannot convert to ArrayBuffer')
 }
 
 bytes.toString = (_from, encoding) => {
-  _from = bytes.from(_from, encoding)
-  const str = String.fromCharCode(...new Uint8Array(_from))
+  _from = bytes(_from, encoding)
+  const uint = new Uint8Array(_from.buffer, _from.byteOffset, _from.byteLength)
+  const str = String.fromCharCode(...uint)
   if (encoding === 'base64') {
+    /* would be nice to find a way to do this directly from a buffer
+     * instead of doing two string conversions
+     */
     return btoa(str)
   } else {
     return str
   }
 }
 
-bytes.native = arg => bytes.from(arg)
+bytes.native = arg => {
+  if (arg instanceof Uint8Array) return arg
+  arg = bytes.from(arg)
+  return new Uint8Array(arg.buffer, arg.byteOffset, arg.byteLength)
+}
 
 module.exports = bytes

--- a/core.js
+++ b/core.js
@@ -9,8 +9,8 @@ const length = (a, b) => {
 const bytes = (_from, encoding) => bytes.from(_from, encoding)
 
 bytes.sort = (a, b) => {
-  a = new DataView(bytes(a))
-  b = new DataView(bytes(b))
+  a = bytes(a)
+  b = bytes(b)
   const len = length(a, b)
   let i = 0
   while (i < (len - 1)) {

--- a/node.js
+++ b/node.js
@@ -3,25 +3,25 @@ const fallback = require('./browser').from
 const bytes = require('./core')
 
 bytes.from = (_from, encoding) => {
-  if (_from instanceof ArrayBuffer) return _from
+  if (_from instanceof DataView) return _from
+  if (_from instanceof ArrayBuffer) return new DataView(_from)
   if (typeof _from === 'string') {
-    return Buffer.alloc(Buffer.byteLength(_from), _from, encoding).buffer
+    _from = Buffer.from(_from, encoding)
   }
   if (Buffer.isBuffer(_from)) {
-    // This Buffer is not a view of a larger ArrayBuffer
-    if (_from.buffer.byteLength === _from.length) return _from.buffer
-    // This Buffer *is* a view of a larger ArrayBuffer so we have to copy it
-    else return _from.buffer.slice(_from.byteOffset, _from.byteOffset + _from.byteLength)
+    return new DataView(_from.buffer, _from.byteOffset, _from.byteLength)
   }
   return fallback(_from, encoding)
 }
 bytes.toString = (_from, encoding) => {
-  return Buffer.from(bytes.from(_from)).toString(encoding)
+  _from = bytes(_from)
+  return Buffer.from(_from.buffer, _from.byteOffset, _from.byteLength).toString(encoding)
 }
 
 bytes.native = arg => {
   if (Buffer.isBuffer(arg)) return arg
-  Buffer.from(bytes.from(arg))
+  arg = bytes(arg)
+  return Buffer.from(arg.buffer, arg.byteOffset, arg.byteLength)
 }
 
 module.exports = bytes

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -10,6 +10,7 @@ const same = (x, y) => assert.ok(tsame(x, y))
 
 test('string conversion', done => {
   const ab = bytes('hello world')
+  assert(ab instanceof DataView)
   const str = bytes.toString(ab)
   same(str, 'hello world')
   done()


### PR DESCRIPTION
BREAKING CHANGE: APIs return DataView instances instead of ArrayBuffer